### PR TITLE
Don't raise a type error on assoc patterns

### DIFF
--- a/level2/derived.lisp
+++ b/level2/derived.lisp
@@ -201,6 +201,7 @@ If :KEY and :TEST is specified, they are passed to ASSOC."
     `(guard1 (,it :type list)
              (listp ,it)
              (let (,flag)
+               (declare (special ,flag))
                (block ,blk
                  (handler-bind ((type-error
                                  (lambda (c)
@@ -212,11 +213,17 @@ If :KEY and :TEST is specified, they are passed to ASSOC."
                    (assoc ,item ,it
                           ,@(when key
                               `(:key (lambda (,x)
-                                       (handler-bind ((type-error (lambda (c) (setf ,flag t))))
+                                       (handler-bind ((type-error (lambda (c)
+                                                                    (let ((,flag t))
+                                                                      (declare (special ,flag))
+                                                                      (signal c)))))
                                          (funcall ,key ,x)))))
                           ,@(when test
                               `(:test (lambda (,x ,y)
-                                        (handler-bind ((type-error (lambda (c) (setf ,flag t))))
+                                        (handler-bind ((type-error (lambda (c)
+                                                                     (let ((,flag t))
+                                                                       (declare (special ,flag))
+                                                                       (signal c)))))
                                           (funcall ,test ,x ,y)))))))))
              (cons _ ,subpattern))))
 

--- a/level2/derived.lisp
+++ b/level2/derived.lisp
@@ -197,14 +197,27 @@ The last argument is matched against the rest of the list."
   "It matches when the object X is a list, and then further matches the contents
 returned by (cdr (assoc item X...)) against SUBPATTERN.
 If :KEY and :TEST is specified, they are passed to ASSOC."
-  (with-gensyms (it)
+  (with-gensyms (it flag x y blk)
     `(guard1 (,it :type list)
              (listp ,it)
-             (handler-case
-                 (assoc ,item ,it
-                        ,@(when key `(:key ,key))
-                        ,@(when test `(:test ,test)))
-               (type-error () nil))
+             (let (,flag)
+               (block ,blk
+                 (handler-bind ((type-error
+                                 (lambda (c)
+                                   (unless ,flag
+                                     ;; for those not familiar with condition system: when flag is set, this
+                                     ;; is an error from :key or :test thus the handler should decline (==
+                                     ;; should not cause control transfer e.g. return-from, go, throw)
+                                     (return-from ,blk nil)))))
+                   (assoc ,item ,it
+                          ,@(when key
+                              `(:key (lambda (,x)
+                                       (handler-bind ((type-error (lambda (c) (setf ,flag t))))
+                                         (funcall ,key ,x)))))
+                          ,@(when test
+                              `(:test (lambda (,x ,y)
+                                        (handler-bind ((type-error (lambda (c) (setf ,flag t))))
+                                          (funcall ,test ,x ,y)))))))))
              (cons _ ,subpattern))))
 
 (defpattern property (key subpattern &optional (default nil) foundp)

--- a/level2/derived.lisp
+++ b/level2/derived.lisp
@@ -200,9 +200,11 @@ If :KEY and :TEST is specified, they are passed to ASSOC."
   (with-gensyms (it)
     `(guard1 (,it :type list)
              (listp ,it)
-             (assoc ,item ,it
-                    ,@(when key `(:key ,key))
-                    ,@(when test `(:test ,test)))
+             (handler-case
+                 (assoc ,item ,it
+                        ,@(when key `(:key ,key))
+                        ,@(when test `(:test ,test)))
+               (type-error () nil))
              (cons _ ,subpattern))))
 
 (defpattern property (key subpattern &optional (default nil) foundp)

--- a/level2/derived.lisp
+++ b/level2/derived.lisp
@@ -194,9 +194,16 @@ The last argument is matched against the rest of the list."
       `(guard1 ,it t (,accessor ,it) ,pattern))))
 
 (defpattern assoc (item subpattern &key (key nil) (test nil))
-  "It matches when the object X is a list, and then further matches the contents
+  "It matches when the object X is a proper association list,
+ and then further matches the contents
 returned by (cdr (assoc item X...)) against SUBPATTERN.
-If :KEY and :TEST is specified, they are passed to ASSOC."
+If :KEY and :TEST are specified, they are passed to ASSOC.
+
+The TYPE-ERROR signaled by ASSOC, which means improper association list,
+is captured by the matcher and is not bubble up outside matcher.
+However, when TYPE-ERROR is signalled by the :test or :key functions,
+they are visible to the environment and the users are required to handle them.
+"
   (with-gensyms (it flag x y blk)
     `(guard1 (,it :type list)
              (listp ,it)

--- a/test/suite.lisp
+++ b/test/suite.lisp
@@ -142,9 +142,12 @@
   (is-not-match '((foo . 2))   (assoc :foo val))
   (is-not-match '(("foo" . 3)) (assoc :foo val))
   (is-not-match '((0 . 4))     (assoc :foo val))
+  (is-not-match '(1)           (assoc :foo val))
+  (is-not-match '((1 . 2) 2)   (assoc :foo val))
   ;; NOTE: incompatibility --- keyword arguments to assoc is evaluated
   ;; (is-match '(("a" . 1)) (assoc "A" 1 :test string-equal))
   (is-match '(("a" . 1)) (assoc "A" 1 :test #'string-equal)))
+
 (test property
   (is-match '(:a 1) (property :a 1))
   (is-match '(:a 1 :b 2) (property :a 1))

--- a/test/suite.lisp
+++ b/test/suite.lisp
@@ -129,8 +129,15 @@
   (is-match '((1 . 2) (3 . 4)) (assoc 3 4))
   ;; NOTE: incompatibility --- this is not an association list, according to CLHS
   ;; (is-match '(1 (2 . 3)) (assoc 2 3))
+  ;; NOTE: old incompatibility --- superceded by the following
+  #+old
   (signals type-error
     (match '(1 (2 . 3)) ((assoc 2 3) t)))
+  ;; NOTE: new incompatibility --- when it is not an assoc list, do not match.
+  (is-not-match '(1 (2 . 3)) (assoc 2 3))
+  ;; issue #54
+  (is-not-match '(1) (assoc :foo val)) ; should not signal error
+
   ;; NOTE: incompatibility --- first argument to assoc should be quoted or constant
   ;; (is-match '((a . 1)) (assoc a 1))
   (is-match '((a . 1)) (assoc 'a 1))


### PR DESCRIPTION
This is a fix for #54, There are still a couple of issues that I'm unsure of how to best address.

- Whether to use handler-case or handler-bind should be used
- The handler-* approach introduces a potential issue. It will 'hide' `type-error`s raised by a key function (if they happen)
- [This incompatibilty](https://github.com/guicho271828/trivia/blob/master/test/suite.lisp#L132) no longer signals a type-error (nor does it appear to match the commented test-case

Note: I pushed the pr branch to the main repo instead of my fork so you could commit to it if you want to