### PR TITLE
Declare unused variable in `ASSOC` pattern.

### DIFF
--- a/level2/derived.lisp
+++ b/level2/derived.lisp
@@ -215,6 +215,7 @@ they are visible to the environment and the users are required to handle them.
                (block ,blk
                  (handler-bind ((type-error
                                  (lambda (c)
+                                   (declare (ignore c))
                                    (unless ,flag
                                      ;; for those not familiar with condition system: when flag is set, this
                                      ;; is an error from :key or :test thus the handler should decline (==


### PR DESCRIPTION
SBCL's warnings about this are annoying. Before this change, compiling
an `ASSOC` or `ALIST` pattern would result in something like:

```
; in: MATCH '((A . 1))
;     (HANDLER-BIND ((TYPE-ERROR
;                     (LAMBDA (TRIVIA.LEVEL2.IMPL::C) (UNLESS #:FLAG775 #))))
;       (ASSOC 'A #:IT774))
; --> SB-IMPL::%HANDLER-BIND SB-INT:DX-FLET
; ==>
;   (FLET ((#:H0 (TRIVIA.LEVEL2.IMPL::C)
;            (UNLESS #:FLAG775 (RETURN-FROM #:BLK778 NIL))))
;     (DECLARE (SB-INT:TRULY-DYNAMIC-EXTENT (FUNCTION #:H0)))
;     (SB-INT:DX-LET ((SB-KERNEL:*HANDLER-CLUSTERS*
;                      (CONS # SB-KERNEL:*HANDLER-CLUSTERS*)))
;       (PROGN (ASSOC 'A #:IT774))))
;
; caught STYLE-WARNING:
;   The variable TRIVIA.LEVEL2.IMPL::C is defined but never used.
;
; compilation unit finished
;   caught 1 STYLE-WARNING condition
```