### PR TITLE
Omit ignorable declarations for symbol-macrolet.

### DIFF
--- a/level2/impl.lisp
+++ b/level2/impl.lisp
@@ -308,7 +308,6 @@ or results in a compilation error when this is the outermost matching construct.
                        ;; if the number of argument is zero, there is no use
                        clauses)))
     `(symbol-macrolet ,bindings
-       (declare (ignorable ,@args))
        (declare ,@(remove nil
                           (mapcar (lambda (arg type)
                                     (unless (eq t type) `(type ,type ,arg)))


### PR DESCRIPTION
The `ignorable` declaration in the macroexpansion of `match2*+` causes both SBCL and Clozure to print compile-time warnings about an ignorable declaration for an unknown variable.

E.g., compiling

``` lisp
(defun foo (x)
  (match x
    ((and x) x)))
````

causes both SBCL and Clozure to complain:

Clozure: `In FOO: IGNORABLE declaration for unknown variable #:ARG213002`
SBCL: `IGNORABLE declaration for an unknown variable: ARG0`

This pull request just removes the ignorable declaration, which is needless anyway, since, as far as I can tell, no Lisp cares if you ignore a symbol macro.