### PR TITLE
Fix type inference in EQ, EQL, EQUAL and EQUALP patterns.

### DIFF
--- a/level2/derived.lisp
+++ b/level2/derived.lisp
@@ -168,28 +168,38 @@ which returns itself if it takes a single argument."
 
 ;; here is a lot of possibility; e.g. strings can be compared in char-wise, etc.
 
+(defun type-of-form (form)
+  (cond ((and (consp form)
+              (eq (first form) 'quote)
+              (consp (rest form))
+              (null (rest (rest form))))
+         `(eql ,(second form)))
+        ((and (atom form)
+              (not (symbolp form)))
+         `(eql ,form))
+        (t 't)))
+
 (defpattern equal (arg)
   "Compare the matching value against ARG (evaluated)."
   (with-gensyms (it)
-    `(guard1 (,it :type ,(if (constantp arg)
-                             (type-of arg) t))
+    `(guard1 (,it :type ,(type-of-form arg))
              (equal ,it ,arg))))
+
 (defpattern equalp (arg)
   "Compare the matching value against ARG (evaluated)."
   (with-gensyms (it)
-    `(guard1 (,it :type ,(if (constantp arg)
-                             (type-of arg) t))
+    `(guard1 (,it :type ,(type-of-form arg))
              (equalp ,it ,arg))))
+
 (defpattern eq (arg)
   "Compare the matching value against ARG (evaluated)."
   (with-gensyms (it)
-    `(guard1 (,it :type (eql ,arg)) (eq ,it ,arg))))
+    `(guard1 (,it :type ,(type-of-form arg)) (eq ,it ,arg))))
+
 (defpattern eql (arg)
   "Compare the matching value against ARG (evaluated)."
   (with-gensyms (it)
-    `(guard1 (,it :type (eql ,arg)) (eql ,it ,arg))))
-
-
+    `(guard1 (,it :type ,(type-of-form arg)) (eql ,it ,arg))))
 
 (defpattern type (type-specifier)
   "Match when (typep OBJ type-specifier) returns true."


### PR DESCRIPTION
Currently, a pattern like `(trivia:lambda-match ('foo 42))` will erroneously add a type declaration of (eql 'foo) to the variable that matches 'foo.  The correct declaration would be (eql foo).  Currently, the automatically generated type declarations for EQ, EQL, EQUAL and EQUALP are wrong for everything but self evaluating objects.

This problem manifests itself when optimizing a pattern like `(trivia:lambda-match ((or 'x 'x) 42))` with the balland2006 optimizer.  Here, SBCL will emit the following warning:

> ;   Derived type of #:fusion5 is
> ;     (values (member x) &optional),
> ;   conflicting with its asserted type
> ;     (values (member (quote x)) &optional).

I attached a potential fix.

PS: Thank you for providing this amazing library!