### PR TITLE
FTBFS LispWorks old versions (5.x, 6.x and 7.0)

### DIFF
--- a/level2/impl.lisp
+++ b/level2/impl.lisp
@@ -361,7 +361,8 @@ or results in a compilation error when this is the outermost matching construct.
 ;; the effect should last after the compilation/load
 (proclaim '(declaration optimizer))
 
-#-(or abcl clasp ecl mezzano clisp)
+#-(or abcl clasp ecl mezzano clisp
+      lispworks5 lispworks6 lispworks7.0) ; hcl:define-declaration was added since LW 7.1
 (trivial-cltl2:define-declaration optimizer (specifier env)
   (declare (ignorable env))
   ;; (print specifier)
@@ -375,7 +376,8 @@ or results in a compilation error when this is the outermost matching construct.
          (clauses (mapcar (curry #'pad (length whats)) clauses)) ; adjust the length of the clauses
          (clauses (mapcar #'expand-clause clauses))
          (clauses* (if args
-                       (funcall (or #-(or abcl clasp ecl mezzano clisp)
+                       (funcall (or #-(or abcl clasp ecl mezzano clisp
+                                          lispworks5 lispworks6 lispworks7.0)
                                     (when-let ((it (trivial-cltl2:declaration-information 'optimizer env)))
                                       (symbol-optimizer it))
                                     (symbol-optimizer *optimizer*))


### PR DESCRIPTION
Hi,

For LispWorks users there's practical need to use open source packages on old versions of LispWorks.

This trivial patch makes your package successfully loaded in LispWorks old versions (5.x, 6.x and 7.0), because the function `trivial-cltl2:define-declaration` (aka `hcl:define-declaration`) was added only after LispWorks 7.1.

Only by using this patch, I can successfully load `fxml` in LispWorks 7.0 on Windows (that's the latest version I paid on that platform). (NOTE: There are other issues stopping `fxml` from being loaded into LispWorks 5.x and 6.x, but irrelevant with your package.)

Regards,

Chun Tian